### PR TITLE
Alternative implementation of array_flatten().

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -1702,7 +1702,7 @@ class util
         $flattened = array();
 
         array_walk_recursive($array, function($value, $key) use (&$flattened, $preserve_keys) {
-            if ($preserve_keys) {
+            if ($preserve_keys && !is_int($key)) {
                 $flattened[$key] = $value;
             } else {
                 $flattened[] = $value;

--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -1697,21 +1697,17 @@ class util
      *                                overwrite keys from shallowy nested arrays
      * @return array
      */
-    public static function array_flatten( array $array, $preserve_keys = TRUE )
+    public static function array_flatten(array $array, $preserve_keys = TRUE)
     {
         $flattened = array();
 
-        foreach ( $array as $key => $value ) {
-            if ( is_array( $value ) ) {
-                $flattened = array_merge( $flattened, self::array_flatten( $value, $preserve_keys ) );
+        array_walk_recursive($array, function($value, $key) use (&$flattened, $preserve_keys) {
+            if ($preserve_keys) {
+                $flattened[$key] = $value;
             } else {
-                if ( $preserve_keys ) {
-                    $flattened[$key] = $value;
-                } else {
-                    $flattened[] = $value;
-                }
+                $flattened[] = $value;
             }
-        }
+        });
 
         return $flattened;
     }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+#session_start();
 require_once dirname(__FILE__) . '/../util.php';
 
 /**
@@ -452,10 +452,21 @@ class UtilityPHPTest extends PHPUnit_Framework_TestCase
 
     public function test_array_flatten()
     {
-        $input = array( 'a', 'b', 'c', 'd', array( 'e', 'f', 'g', array( 'h', 'i', array( array( array( array( 'j', 'k', 'l' ) ) ) ) ) ) );
-        $expect = range( 'a', 'l' );
+        $input = array( 'a', 'b', 'c', 'd', array( 'first' => 'e', 'f', 'second' => 'g', array( 'h', 'third' => 'i', array( array( array( array( 'j', 'k', 'l' ) ) ) ) ) ) );
+        $expectNoKeys = range( 'a', 'l' );
+        $expectWithKeys = array(
+            'a', 'b', 'c', 'd',
+            'first' => 'e',
+            'f',
+            'second' => 'g',
+            'h',
+            'third' => 'i',
+            'j', 'k', 'l'
+        );
 
-        $this->assertEquals( $expect, util::array_flatten( $input ) );
+        $this->assertEquals( $expectWithKeys, util::array_flatten( $input ) );
+        $this->assertEquals( $expectNoKeys, util::array_flatten( $input, false ) );
+        $this->assertEquals( $expectWithKeys, util::array_flatten( $input, true ) );
     }
 
     public function test_strip_space()


### PR DESCRIPTION
A more performant version of *util::array_flatten*, utilizing the core PHP function *array_walk_recursive*. 

Updated to support UtilPHP's handling of numerical indexes.