### PR TITLE
Added util::fix_broken_serialization() which fixes common serialization ...

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -632,6 +632,25 @@ class util
     }
 
     /**
+     * Unserializes partially-corrupted arrays that occur sometimes. Addresses specifically the
+     * `unserialize(): Error at offset xxx of yyy bytes` error.
+     *
+     * NOTE: This error can *frequently* occur with mismatched character sets and higher-than-ASCII characters.
+     *
+     * @param $brokenSerializedData
+     * @return string
+     */
+    public static function fix_broken_serialization( $brokenSerializedData )
+    {
+        $fixdSerializedData = preg_replace_callback('!s:(\d+):"(.*?)";!', function($matches) {
+            $snip = $matches[2];
+            return 's:' . strlen($snip) . ':"' . $snip . '";';
+        }, $brokenSerializedData);
+
+        return $fixdSerializedData;
+    }
+
+    /**
      * Checks to see if the page is being server over SSL or not
      *
      * @return boolean


### PR DESCRIPTION
...problems.

There are four primary reasons PHP serialize() will break:
0. A developer edits a serialized string and forgets to change (or incorrectly changes) the string length value.
1. CharacterSet mismatches (e.g., PHP running in ISO-8859-1 [default pre-5.4] and
   the database running in UTF-8, and higher-than-ASCII characters being used.
2. Improper escaping by userland code or the database.
3. Accidentally truncated data (think: DB column data type is too small for the data).

This function fixes all of those, by introspecting each string in the serialized data,
including key names, class property names, and values, and recalculating their now-current
sizes.

I have found this method essential in running foreign language sites, when faced with many
misconfigured browsers forcing wrong charactersets on the website.