### PR TITLE
Added new method 'secure_random_string'

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -89,26 +89,26 @@ class util
      *
      * @see https://github.com/jbroadway/urlify/blob/master/URLify.php
      */
-    public static $maps = array(
-        'de' => array( /* German */
+    public static $maps = [
+        'de' => [ /* German */
             'Ä' => 'Ae', 'Ö' => 'Oe', 'Ü' => 'Ue', 'ä' => 'ae', 'ö' => 'oe', 'ü' => 'ue', 'ß' => 'ss',
             'ẞ' => 'SS'
-        ),
-        'latin' => array(
+        ],
+        'latin' => [
             'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A','Ă' => 'A', 'Æ' => 'AE', 'Ç' =>
-            'C', 'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I',
+                'C', 'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I',
             'Ï' => 'I', 'Ð' => 'D', 'Ñ' => 'N', 'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' =>
-            'O', 'Ő' => 'O', 'Ø' => 'O','Ș' => 'S','Ț' => 'T', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U',
+                'O', 'Ő' => 'O', 'Ø' => 'O','Ș' => 'S','Ț' => 'T', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U',
             'Ý' => 'Y', 'Þ' => 'TH', 'ß' => 'ss', 'à' => 'a', 'á' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' =>
-            'a', 'å' => 'a', 'ă' => 'a', 'æ' => 'ae', 'ç' => 'c', 'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
+                'a', 'å' => 'a', 'ă' => 'a', 'æ' => 'ae', 'ç' => 'c', 'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
             'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i', 'ð' => 'd', 'ñ' => 'n', 'ò' => 'o', 'ó' =>
-            'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o', 'ø' => 'o', 'ș' => 's', 'ț' => 't', 'ù' => 'u', 'ú' => 'u',
+                'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o', 'ø' => 'o', 'ș' => 's', 'ț' => 't', 'ù' => 'u', 'ú' => 'u',
             'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th', 'ÿ' => 'y'
-        ),
-        'latin_symbols' => array(
+        ],
+        'latin_symbols' => [
             '©' => '(c)'
-        ),
-        'el' => array( /* Greek */
+        ],
+        'el' => [ /* Greek */
             'α' => 'a', 'β' => 'b', 'γ' => 'g', 'δ' => 'd', 'ε' => 'e', 'ζ' => 'z', 'η' => 'h', 'θ' => '8',
             'ι' => 'i', 'κ' => 'k', 'λ' => 'l', 'μ' => 'm', 'ν' => 'n', 'ξ' => '3', 'ο' => 'o', 'π' => 'p',
             'ρ' => 'r', 'σ' => 's', 'τ' => 't', 'υ' => 'y', 'φ' => 'f', 'χ' => 'x', 'ψ' => 'ps', 'ω' => 'w',
@@ -119,12 +119,12 @@ class util
             'Ρ' => 'R', 'Σ' => 'S', 'Τ' => 'T', 'Υ' => 'Y', 'Φ' => 'F', 'Χ' => 'X', 'Ψ' => 'PS', 'Ω' => 'W',
             'Ά' => 'A', 'Έ' => 'E', 'Ί' => 'I', 'Ό' => 'O', 'Ύ' => 'Y', 'Ή' => 'H', 'Ώ' => 'W', 'Ϊ' => 'I',
             'Ϋ' => 'Y'
-        ),
-        'tr' => array( /* Turkish */
+        ],
+        'tr' => [ /* Turkish */
             'ş' => 's', 'Ş' => 'S', 'ı' => 'i', 'İ' => 'I', 'ç' => 'c', 'Ç' => 'C', 'ü' => 'u', 'Ü' => 'U',
             'ö' => 'o', 'Ö' => 'O', 'ğ' => 'g', 'Ğ' => 'G'
-        ),
-        'ru' => array( /* Russian */
+        ],
+        'ru' => [ /* Russian */
             'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh',
             'з' => 'z', 'и' => 'i', 'й' => 'j', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n', 'о' => 'o',
             'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c',
@@ -136,33 +136,33 @@ class util
             'Ч' => 'Ch', 'Ш' => 'Sh', 'Щ' => 'Sh', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'Yu',
             'Я' => 'Ya',
             '№' => ''
-        ),
-        'uk' => array( /* Ukrainian */
+        ],
+        'uk' => [ /* Ukrainian */
             'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'Ґ' => 'G', 'є' => 'ye', 'і' => 'i', 'ї' => 'yi', 'ґ' => 'g'
-        ),
-        'cs' => array( /* Czech */
+        ],
+        'cs' => [ /* Czech */
             'č' => 'c', 'ď' => 'd', 'ě' => 'e', 'ň' => 'n', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ů' => 'u',
             'ž' => 'z', 'Č' => 'C', 'Ď' => 'D', 'Ě' => 'E', 'Ň' => 'N', 'Ř' => 'R', 'Š' => 'S', 'Ť' => 'T',
             'Ů' => 'U', 'Ž' => 'Z'
-        ),
-        'pl' => array( /* Polish */
+        ],
+        'pl' => [ /* Polish */
             'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z',
             'ż' => 'z', 'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'e', 'Ł' => 'L', 'Ń' => 'N', 'Ó' => 'O', 'Ś' => 'S',
             'Ź' => 'Z', 'Ż' => 'Z'
-        ),
-        'ro' => array( /* Romanian */
+        ],
+        'ro' => [ /* Romanian */
             'ă' => 'a', 'â' => 'a', 'î' => 'i', 'ș' => 's', 'ț' => 't', 'Ţ' => 'T', 'ţ' => 't'
-        ),
-        'lv' => array( /* Latvian */
+        ],
+        'lv' => [ /* Latvian */
             'ā' => 'a', 'č' => 'c', 'ē' => 'e', 'ģ' => 'g', 'ī' => 'i', 'ķ' => 'k', 'ļ' => 'l', 'ņ' => 'n',
             'š' => 's', 'ū' => 'u', 'ž' => 'z', 'Ā' => 'A', 'Č' => 'C', 'Ē' => 'E', 'Ģ' => 'G', 'Ī' => 'i',
             'Ķ' => 'k', 'Ļ' => 'L', 'Ņ' => 'N', 'Š' => 'S', 'Ū' => 'u', 'Ž' => 'Z'
-        ),
-        'lt' => array( /* Lithuanian */
+        ],
+        'lt' => [ /* Lithuanian */
             'ą' => 'a', 'č' => 'c', 'ę' => 'e', 'ė' => 'e', 'į' => 'i', 'š' => 's', 'ų' => 'u', 'ū' => 'u', 'ž' => 'z',
             'Ą' => 'A', 'Č' => 'C', 'Ę' => 'E', 'Ė' => 'E', 'Į' => 'I', 'Š' => 'S', 'Ų' => 'U', 'Ū' => 'U', 'Ž' => 'Z'
-        ),
-        'vn' => array( /* Vietnamese */
+        ],
+        'vn' => [ /* Vietnamese */
             'Á' => 'A', 'À' => 'A', 'Ả' => 'A', 'Ã' => 'A', 'Ạ' => 'A', 'Ă' => 'A', 'Ắ' => 'A', 'Ằ' => 'A', 'Ẳ' => 'A', 'Ẵ' => 'A', 'Ặ' => 'A', 'Â' => 'A', 'Ấ' => 'A', 'Ầ' => 'A', 'Ẩ' => 'A', 'Ẫ' => 'A', 'Ậ' => 'A',
             'á' => 'a', 'à' => 'a', 'ả' => 'a', 'ã' => 'a', 'ạ' => 'a', 'ă' => 'a', 'ắ' => 'a', 'ằ' => 'a', 'ẳ' => 'a', 'ẵ' => 'a', 'ặ' => 'a', 'â' => 'a', 'ấ' => 'a', 'ầ' => 'a', 'ẩ' => 'a', 'ẫ' => 'a', 'ậ' => 'a',
             'É' => 'E', 'È' => 'E', 'Ẻ' => 'E', 'Ẽ' => 'E', 'Ẹ' => 'E', 'Ê' => 'E', 'Ế' => 'E', 'Ề' => 'E', 'Ể' => 'E', 'Ễ' => 'E', 'Ệ' => 'E',
@@ -174,29 +174,29 @@ class util
             'ú' => 'u', 'ù' => 'u', 'ủ' => 'u', 'ũ' => 'u', 'ụ' => 'u', 'ư' => 'u', 'ứ' => 'u', 'ừ' => 'u', 'ử' => 'u', 'ữ' => 'u', 'ự' => 'u',
             'Ý' => 'Y', 'Ỳ' => 'Y', 'Ỷ' => 'Y', 'Ỹ' => 'Y', 'Ỵ' => 'Y', 'ý' => 'y', 'ỳ' => 'y', 'ỷ' => 'y', 'ỹ' => 'y', 'ỵ' => 'y',
             'Đ' => 'D', 'đ' => 'd'
-        ),
-        'ar' => array( /* Arabic */
+        ],
+        'ar' => [ /* Arabic */
             'أ' => 'a', 'ب' => 'b', 'ت' => 't', 'ث' => 'th', 'ج' => 'g', 'ح' => 'h', 'خ' => 'kh', 'د' => 'd',
             'ذ' => 'th', 'ر' => 'r', 'ز' => 'z', 'س' => 's', 'ش' => 'sh', 'ص' => 's', 'ض' => 'd', 'ط' => 't',
             'ظ' => 'th', 'ع' => 'aa', 'غ' => 'gh', 'ف' => 'f', 'ق' => 'k', 'ك' => 'k', 'ل' => 'l', 'م' => 'm',
             'ن' => 'n', 'ه' => 'h', 'و' => 'o', 'ي' => 'y'
-        ),
-        'sr' => array( /* Serbian */
+        ],
+        'sr' => [ /* Serbian */
             'ђ' => 'dj', 'ј' => 'j', 'љ' => 'lj', 'њ' => 'nj', 'ћ' => 'c', 'џ' => 'dz', 'đ' => 'dj',
             'Ђ' => 'Dj', 'Ј' => 'j', 'Љ' => 'Lj', 'Њ' => 'Nj', 'Ћ' => 'C', 'Џ' => 'Dz', 'Đ' => 'Dj'
-        ),
-        'az' => array( /* Azerbaijani */
+        ],
+        'az' => [ /* Azerbaijani */
             'ç' => 'c', 'ə' => 'e', 'ğ' => 'g', 'ı' => 'i', 'ö' => 'o', 'ş' => 's', 'ü' => 'u',
             'Ç' => 'C', 'Ə' => 'E', 'Ğ' => 'G', 'İ' => 'I', 'Ö' => 'O', 'Ş' => 'S', 'Ü' => 'U'
-        ),
-    );
+        ],
+    ];
 
     /**
      * The character map for the designated language
      *
      * @see https://github.com/jbroadway/urlify/blob/master/URLify.php
      */
-    private static $map = array();
+    private static $map = [];
 
     /**
      * The character list as a string.
@@ -240,7 +240,7 @@ class util
 
         // Reset static vars
         self::$language = $language;
-        self::$map = array();
+        self::$map = [];
         self::$chars = '';
 
         foreach (self::$maps as $map) {
@@ -303,7 +303,7 @@ class util
             'word-wrap: break-word;' .
             'color: #333;' .
             'font-family: Menlo,Monaco,Consolas,\'Courier New\',monospace;">';
-        $done  = array();
+        $done  = [];
         $html .= self::var_dump_plain( $var , intval($expandLevel), 0, $done);
         $html .= '</pre>';
 
@@ -327,7 +327,7 @@ class util
      * @param  mixed $var The variable to dump
      * @return string
      */
-    public static function var_dump_plain( $var , $expLevel, $depth = 0, $done = array() )
+    public static function var_dump_plain( $var , $expLevel, $depth = 0, $done = [] )
     {
         $html = '';
 
@@ -493,7 +493,7 @@ class util
         $slug = preg_replace( '/([^a-z0-9]+)/', '-', strtolower( self::remove_accents( $string ) ) );
 
         if ( $css_mode ) {
-            $digits = array( 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine' );
+            $digits = [ 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine' ];
 
             if ( is_numeric( substr( $slug, 0, 1 ) ) ) {
                 $slug = $digits[substr( $slug, 0, 1 )] . substr( $slug, 1 );
@@ -586,7 +586,7 @@ class util
      */
     public static function maybe_unserialize( $data )
     {
-         // Don't attempt to unserialize data that isn't serialized
+        // Don't attempt to unserialize data that isn't serialized
         if ( self::is_serialized( $data ) ) {
             return @unserialize( $data );
         }
@@ -963,8 +963,8 @@ class util
 
             // These latin characters should be represented by two characters so
             // we can't use strtr
-            $complexSearch  = array("\x8c", "\x9c", "\xc6", "\xd0", "\xde", "\xdf", "\xe6", "\xf0", "\xfe");
-            $complexReplace = array('OE', 'oe', 'AE', 'DH', 'TH', 'ss', 'ae', 'dh', 'th');
+            $complexSearch  = ["\x8c", "\x9c", "\xc6", "\xd0", "\xde", "\xdf", "\xe6", "\xf0", "\xfe"];
+            $complexReplace = ['OE', 'oe', 'AE', 'DH', 'TH', 'ss', 'ae', 'dh', 'th'];
             $text           = str_replace($complexSearch, $complexReplace, $text);
         }
 
@@ -1125,7 +1125,7 @@ class util
             $group  = rtrim( chunk_split( $number, 3, ' ' ), ' ' );
             $groups = explode( ' ', $group );
 
-            $groups2 = array();
+            $groups2 = [];
 
             foreach ( $groups as $group ) {
                 $groups2[] = self::_number_to_word_three_digits( $group[0], $group[1], $group[2] );
@@ -1349,7 +1349,7 @@ class util
             header( 'Content-Transfer-Encoding: binary' );
 
             if ( $content ) {
-               header( 'Content-Length: ' . strlen( $content ) );
+                header( 'Content-Length: ' . strlen( $content ) );
             }
 
             ob_clean();
@@ -1410,7 +1410,7 @@ class util
      *                                      characters once in the string.
      * @return  string
      */
-    public static function random_string( $length, $human_friendly = TRUE, $include_symbols = FALSE, $no_duplicate_chars = FALSE )
+    public static function random_string( $length = 16, $human_friendly = TRUE, $include_symbols = FALSE, $no_duplicate_chars = FALSE )
     {
         $nice_chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefhjkmnprstuvwxyz23456789';
         $all_an     = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890';
@@ -1450,6 +1450,29 @@ class util
         }
 
         return $string;
+    }
+
+    /**
+     * Generate secure random string of given length
+     * If 'openssl_random_pseudo_bytes' is not available
+     * then generate random string using default function
+     *
+     * @param int $length length of string
+     * @return bool
+     */
+    public static function secure_random_string( $length = 16 )
+    {
+        if (function_exists('openssl_random_pseudo_bytes'))
+        {
+            $bytes = openssl_random_pseudo_bytes( $length * 2 );
+            if ( $bytes === FALSE )
+            {
+                throw new \RuntimeException('Unable to generate random string.');
+            }
+            return substr( str_replace( ['/', '+', '='], '', base64_encode( $bytes )), 0, $length );
+        }
+
+        return static::random_string($length);
     }
 
     /**
@@ -1505,7 +1528,7 @@ class util
               )                              # End $2:
             %ix';
 
-        return preg_replace_callback( $section_html_pattern, array( __CLASS__, '_linkify_callback' ), $text );
+        return preg_replace_callback( $section_html_pattern, [ __CLASS__, '_linkify_callback' ], $text );
     }
 
     /**
@@ -1743,22 +1766,22 @@ class util
         $info .= ( ( $perms & 0x0100 ) ? 'r' : '-' );
         $info .= ( ( $perms & 0x0080 ) ? 'w' : '-' );
         $info .= ( ( $perms & 0x0040 ) ?
-                    ( ( $perms & 0x0800 ) ? 's' : 'x' ) :
-                    ( ( $perms & 0x0800 ) ? 'S' : '-' ) );
+            ( ( $perms & 0x0800 ) ? 's' : 'x' ) :
+            ( ( $perms & 0x0800 ) ? 'S' : '-' ) );
 
         // Group
         $info .= ( ( $perms & 0x0020 ) ? 'r' : '-' );
         $info .= ( ( $perms & 0x0010 ) ? 'w' : '-' );
         $info .= ( ( $perms & 0x0008 ) ?
-                    ( ( $perms & 0x0400 ) ? 's' : 'x' ) :
-                    ( ( $perms & 0x0400 ) ? 'S' : '-' ) );
+            ( ( $perms & 0x0400 ) ? 's' : 'x' ) :
+            ( ( $perms & 0x0400 ) ? 'S' : '-' ) );
 
         // World
         $info .= ( ( $perms & 0x0004 ) ? 'r' : '-' );
         $info .= ( ( $perms & 0x0002 ) ? 'w' : '-' );
         $info .= ( ( $perms & 0x0001 ) ?
-                    ( ( $perms & 0x0200 ) ? 't' : 'x' ) :
-                    ( ( $perms & 0x0200 ) ? 'T' : '-' ) );
+            ( ( $perms & 0x0200 ) ? 't' : 'x' ) :
+            ( ( $perms & 0x0200 ) ? 'T' : '-' ) );
 
         return $info;
     }
@@ -1822,7 +1845,7 @@ class util
      */
     public static function array_flatten(array $array, $preserve_keys = TRUE)
     {
-        $flattened = array();
+        $flattened = [];
 
         array_walk_recursive($array, function($value, $key) use (&$flattened, $preserve_keys) {
             if ($preserve_keys && !is_int($key)) {
@@ -1851,7 +1874,7 @@ class util
      */
     public static function array_pluck( array $array, $field, $preserve_keys = TRUE, $remove_nomatches = TRUE )
     {
-        $new_list = array();
+        $new_list = [];
 
         foreach ( $array as $key => $value ) {
             if ( is_object( $value ) ) {
@@ -1944,8 +1967,8 @@ class util
     {
         foreach ( $array as $key => $value ) {
             if ( is_array( $value ) ) {
-                $args = array( $value, $callback, $on_nonscalar );
-                $array[$key] = call_user_func_array( array( __CLASS__, __FUNCTION__ ), $args );
+                $args = [ $value, $callback, $on_nonscalar ];
+                $array[$key] = call_user_func_array( [ __CLASS__, __FUNCTION__ ], $args );
             } else if ( is_scalar( $value ) || $on_nonscalar ) {
                 $array[$key] = call_user_func( $callback, $value );
             }

--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -89,26 +89,26 @@ class util
      *
      * @see https://github.com/jbroadway/urlify/blob/master/URLify.php
      */
-    public static $maps = [
-        'de' => [ /* German */
+    public static $maps = array(
+        'de' => array( /* German */
             'Ä' => 'Ae', 'Ö' => 'Oe', 'Ü' => 'Ue', 'ä' => 'ae', 'ö' => 'oe', 'ü' => 'ue', 'ß' => 'ss',
             'ẞ' => 'SS'
-        ],
-        'latin' => [
+        ),
+        'latin' => array(
             'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A','Ă' => 'A', 'Æ' => 'AE', 'Ç' =>
-                'C', 'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I',
+            'C', 'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I',
             'Ï' => 'I', 'Ð' => 'D', 'Ñ' => 'N', 'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' =>
-                'O', 'Ő' => 'O', 'Ø' => 'O','Ș' => 'S','Ț' => 'T', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U',
+            'O', 'Ő' => 'O', 'Ø' => 'O','Ș' => 'S','Ț' => 'T', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U',
             'Ý' => 'Y', 'Þ' => 'TH', 'ß' => 'ss', 'à' => 'a', 'á' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' =>
-                'a', 'å' => 'a', 'ă' => 'a', 'æ' => 'ae', 'ç' => 'c', 'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
+            'a', 'å' => 'a', 'ă' => 'a', 'æ' => 'ae', 'ç' => 'c', 'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
             'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i', 'ð' => 'd', 'ñ' => 'n', 'ò' => 'o', 'ó' =>
-                'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o', 'ø' => 'o', 'ș' => 's', 'ț' => 't', 'ù' => 'u', 'ú' => 'u',
+            'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o', 'ø' => 'o', 'ș' => 's', 'ț' => 't', 'ù' => 'u', 'ú' => 'u',
             'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th', 'ÿ' => 'y'
-        ],
-        'latin_symbols' => [
+        ),
+        'latin_symbols' => array(
             '©' => '(c)'
-        ],
-        'el' => [ /* Greek */
+        ),
+        'el' => array( /* Greek */
             'α' => 'a', 'β' => 'b', 'γ' => 'g', 'δ' => 'd', 'ε' => 'e', 'ζ' => 'z', 'η' => 'h', 'θ' => '8',
             'ι' => 'i', 'κ' => 'k', 'λ' => 'l', 'μ' => 'm', 'ν' => 'n', 'ξ' => '3', 'ο' => 'o', 'π' => 'p',
             'ρ' => 'r', 'σ' => 's', 'τ' => 't', 'υ' => 'y', 'φ' => 'f', 'χ' => 'x', 'ψ' => 'ps', 'ω' => 'w',
@@ -119,12 +119,12 @@ class util
             'Ρ' => 'R', 'Σ' => 'S', 'Τ' => 'T', 'Υ' => 'Y', 'Φ' => 'F', 'Χ' => 'X', 'Ψ' => 'PS', 'Ω' => 'W',
             'Ά' => 'A', 'Έ' => 'E', 'Ί' => 'I', 'Ό' => 'O', 'Ύ' => 'Y', 'Ή' => 'H', 'Ώ' => 'W', 'Ϊ' => 'I',
             'Ϋ' => 'Y'
-        ],
-        'tr' => [ /* Turkish */
+        ),
+        'tr' => array( /* Turkish */
             'ş' => 's', 'Ş' => 'S', 'ı' => 'i', 'İ' => 'I', 'ç' => 'c', 'Ç' => 'C', 'ü' => 'u', 'Ü' => 'U',
             'ö' => 'o', 'Ö' => 'O', 'ğ' => 'g', 'Ğ' => 'G'
-        ],
-        'ru' => [ /* Russian */
+        ),
+        'ru' => array( /* Russian */
             'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh',
             'з' => 'z', 'и' => 'i', 'й' => 'j', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n', 'о' => 'o',
             'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c',
@@ -136,33 +136,33 @@ class util
             'Ч' => 'Ch', 'Ш' => 'Sh', 'Щ' => 'Sh', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'Yu',
             'Я' => 'Ya',
             '№' => ''
-        ],
-        'uk' => [ /* Ukrainian */
+        ),
+        'uk' => array( /* Ukrainian */
             'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'Ґ' => 'G', 'є' => 'ye', 'і' => 'i', 'ї' => 'yi', 'ґ' => 'g'
-        ],
-        'cs' => [ /* Czech */
+        ),
+        'cs' => array( /* Czech */
             'č' => 'c', 'ď' => 'd', 'ě' => 'e', 'ň' => 'n', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ů' => 'u',
             'ž' => 'z', 'Č' => 'C', 'Ď' => 'D', 'Ě' => 'E', 'Ň' => 'N', 'Ř' => 'R', 'Š' => 'S', 'Ť' => 'T',
             'Ů' => 'U', 'Ž' => 'Z'
-        ],
-        'pl' => [ /* Polish */
+        ),
+        'pl' => array( /* Polish */
             'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z',
             'ż' => 'z', 'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'e', 'Ł' => 'L', 'Ń' => 'N', 'Ó' => 'O', 'Ś' => 'S',
             'Ź' => 'Z', 'Ż' => 'Z'
-        ],
-        'ro' => [ /* Romanian */
+        ),
+        'ro' => array( /* Romanian */
             'ă' => 'a', 'â' => 'a', 'î' => 'i', 'ș' => 's', 'ț' => 't', 'Ţ' => 'T', 'ţ' => 't'
-        ],
-        'lv' => [ /* Latvian */
+        ),
+        'lv' => array( /* Latvian */
             'ā' => 'a', 'č' => 'c', 'ē' => 'e', 'ģ' => 'g', 'ī' => 'i', 'ķ' => 'k', 'ļ' => 'l', 'ņ' => 'n',
             'š' => 's', 'ū' => 'u', 'ž' => 'z', 'Ā' => 'A', 'Č' => 'C', 'Ē' => 'E', 'Ģ' => 'G', 'Ī' => 'i',
             'Ķ' => 'k', 'Ļ' => 'L', 'Ņ' => 'N', 'Š' => 'S', 'Ū' => 'u', 'Ž' => 'Z'
-        ],
-        'lt' => [ /* Lithuanian */
+        ),
+        'lt' => array( /* Lithuanian */
             'ą' => 'a', 'č' => 'c', 'ę' => 'e', 'ė' => 'e', 'į' => 'i', 'š' => 's', 'ų' => 'u', 'ū' => 'u', 'ž' => 'z',
             'Ą' => 'A', 'Č' => 'C', 'Ę' => 'E', 'Ė' => 'E', 'Į' => 'I', 'Š' => 'S', 'Ų' => 'U', 'Ū' => 'U', 'Ž' => 'Z'
-        ],
-        'vn' => [ /* Vietnamese */
+        ),
+        'vn' => array( /* Vietnamese */
             'Á' => 'A', 'À' => 'A', 'Ả' => 'A', 'Ã' => 'A', 'Ạ' => 'A', 'Ă' => 'A', 'Ắ' => 'A', 'Ằ' => 'A', 'Ẳ' => 'A', 'Ẵ' => 'A', 'Ặ' => 'A', 'Â' => 'A', 'Ấ' => 'A', 'Ầ' => 'A', 'Ẩ' => 'A', 'Ẫ' => 'A', 'Ậ' => 'A',
             'á' => 'a', 'à' => 'a', 'ả' => 'a', 'ã' => 'a', 'ạ' => 'a', 'ă' => 'a', 'ắ' => 'a', 'ằ' => 'a', 'ẳ' => 'a', 'ẵ' => 'a', 'ặ' => 'a', 'â' => 'a', 'ấ' => 'a', 'ầ' => 'a', 'ẩ' => 'a', 'ẫ' => 'a', 'ậ' => 'a',
             'É' => 'E', 'È' => 'E', 'Ẻ' => 'E', 'Ẽ' => 'E', 'Ẹ' => 'E', 'Ê' => 'E', 'Ế' => 'E', 'Ề' => 'E', 'Ể' => 'E', 'Ễ' => 'E', 'Ệ' => 'E',
@@ -174,29 +174,29 @@ class util
             'ú' => 'u', 'ù' => 'u', 'ủ' => 'u', 'ũ' => 'u', 'ụ' => 'u', 'ư' => 'u', 'ứ' => 'u', 'ừ' => 'u', 'ử' => 'u', 'ữ' => 'u', 'ự' => 'u',
             'Ý' => 'Y', 'Ỳ' => 'Y', 'Ỷ' => 'Y', 'Ỹ' => 'Y', 'Ỵ' => 'Y', 'ý' => 'y', 'ỳ' => 'y', 'ỷ' => 'y', 'ỹ' => 'y', 'ỵ' => 'y',
             'Đ' => 'D', 'đ' => 'd'
-        ],
-        'ar' => [ /* Arabic */
+        ),
+        'ar' => array( /* Arabic */
             'أ' => 'a', 'ب' => 'b', 'ت' => 't', 'ث' => 'th', 'ج' => 'g', 'ح' => 'h', 'خ' => 'kh', 'د' => 'd',
             'ذ' => 'th', 'ر' => 'r', 'ز' => 'z', 'س' => 's', 'ش' => 'sh', 'ص' => 's', 'ض' => 'd', 'ط' => 't',
             'ظ' => 'th', 'ع' => 'aa', 'غ' => 'gh', 'ف' => 'f', 'ق' => 'k', 'ك' => 'k', 'ل' => 'l', 'م' => 'm',
             'ن' => 'n', 'ه' => 'h', 'و' => 'o', 'ي' => 'y'
-        ],
-        'sr' => [ /* Serbian */
+        ),
+        'sr' => array( /* Serbian */
             'ђ' => 'dj', 'ј' => 'j', 'љ' => 'lj', 'њ' => 'nj', 'ћ' => 'c', 'џ' => 'dz', 'đ' => 'dj',
             'Ђ' => 'Dj', 'Ј' => 'j', 'Љ' => 'Lj', 'Њ' => 'Nj', 'Ћ' => 'C', 'Џ' => 'Dz', 'Đ' => 'Dj'
-        ],
-        'az' => [ /* Azerbaijani */
+        ),
+        'az' => array( /* Azerbaijani */
             'ç' => 'c', 'ə' => 'e', 'ğ' => 'g', 'ı' => 'i', 'ö' => 'o', 'ş' => 's', 'ü' => 'u',
             'Ç' => 'C', 'Ə' => 'E', 'Ğ' => 'G', 'İ' => 'I', 'Ö' => 'O', 'Ş' => 'S', 'Ü' => 'U'
-        ],
-    ];
+        ),
+    );
 
     /**
      * The character map for the designated language
      *
      * @see https://github.com/jbroadway/urlify/blob/master/URLify.php
      */
-    private static $map = [];
+    private static $map = array();
 
     /**
      * The character list as a string.
@@ -240,7 +240,7 @@ class util
 
         // Reset static vars
         self::$language = $language;
-        self::$map = [];
+        self::$map = array();
         self::$chars = '';
 
         foreach (self::$maps as $map) {
@@ -303,7 +303,7 @@ class util
             'word-wrap: break-word;' .
             'color: #333;' .
             'font-family: Menlo,Monaco,Consolas,\'Courier New\',monospace;">';
-        $done  = [];
+        $done  = array();
         $html .= self::var_dump_plain( $var , intval($expandLevel), 0, $done);
         $html .= '</pre>';
 
@@ -327,7 +327,7 @@ class util
      * @param  mixed $var The variable to dump
      * @return string
      */
-    public static function var_dump_plain( $var , $expLevel, $depth = 0, $done = [] )
+    public static function var_dump_plain( $var , $expLevel, $depth = 0, $done = array() )
     {
         $html = '';
 
@@ -493,7 +493,7 @@ class util
         $slug = preg_replace( '/([^a-z0-9]+)/', '-', strtolower( self::remove_accents( $string ) ) );
 
         if ( $css_mode ) {
-            $digits = [ 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine' ];
+            $digits = array( 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine' );
 
             if ( is_numeric( substr( $slug, 0, 1 ) ) ) {
                 $slug = $digits[substr( $slug, 0, 1 )] . substr( $slug, 1 );
@@ -586,7 +586,7 @@ class util
      */
     public static function maybe_unserialize( $data )
     {
-        // Don't attempt to unserialize data that isn't serialized
+         // Don't attempt to unserialize data that isn't serialized
         if ( self::is_serialized( $data ) ) {
             return @unserialize( $data );
         }
@@ -963,8 +963,8 @@ class util
 
             // These latin characters should be represented by two characters so
             // we can't use strtr
-            $complexSearch  = ["\x8c", "\x9c", "\xc6", "\xd0", "\xde", "\xdf", "\xe6", "\xf0", "\xfe"];
-            $complexReplace = ['OE', 'oe', 'AE', 'DH', 'TH', 'ss', 'ae', 'dh', 'th'];
+            $complexSearch  = array("\x8c", "\x9c", "\xc6", "\xd0", "\xde", "\xdf", "\xe6", "\xf0", "\xfe");
+            $complexReplace = array('OE', 'oe', 'AE', 'DH', 'TH', 'ss', 'ae', 'dh', 'th');
             $text           = str_replace($complexSearch, $complexReplace, $text);
         }
 
@@ -1125,7 +1125,7 @@ class util
             $group  = rtrim( chunk_split( $number, 3, ' ' ), ' ' );
             $groups = explode( ' ', $group );
 
-            $groups2 = [];
+            $groups2 = array();
 
             foreach ( $groups as $group ) {
                 $groups2[] = self::_number_to_word_three_digits( $group[0], $group[1], $group[2] );
@@ -1349,7 +1349,7 @@ class util
             header( 'Content-Transfer-Encoding: binary' );
 
             if ( $content ) {
-                header( 'Content-Length: ' . strlen( $content ) );
+               header( 'Content-Length: ' . strlen( $content ) );
             }
 
             ob_clean();
@@ -1471,7 +1471,6 @@ class util
             }
             return substr( str_replace( ['/', '+', '='], '', base64_encode( $bytes )), 0, $length );
         }
-
         return static::random_string($length);
     }
 
@@ -1528,7 +1527,7 @@ class util
               )                              # End $2:
             %ix';
 
-        return preg_replace_callback( $section_html_pattern, [ __CLASS__, '_linkify_callback' ], $text );
+        return preg_replace_callback( $section_html_pattern, array( __CLASS__, '_linkify_callback' ), $text );
     }
 
     /**
@@ -1766,22 +1765,22 @@ class util
         $info .= ( ( $perms & 0x0100 ) ? 'r' : '-' );
         $info .= ( ( $perms & 0x0080 ) ? 'w' : '-' );
         $info .= ( ( $perms & 0x0040 ) ?
-            ( ( $perms & 0x0800 ) ? 's' : 'x' ) :
-            ( ( $perms & 0x0800 ) ? 'S' : '-' ) );
+                    ( ( $perms & 0x0800 ) ? 's' : 'x' ) :
+                    ( ( $perms & 0x0800 ) ? 'S' : '-' ) );
 
         // Group
         $info .= ( ( $perms & 0x0020 ) ? 'r' : '-' );
         $info .= ( ( $perms & 0x0010 ) ? 'w' : '-' );
         $info .= ( ( $perms & 0x0008 ) ?
-            ( ( $perms & 0x0400 ) ? 's' : 'x' ) :
-            ( ( $perms & 0x0400 ) ? 'S' : '-' ) );
+                    ( ( $perms & 0x0400 ) ? 's' : 'x' ) :
+                    ( ( $perms & 0x0400 ) ? 'S' : '-' ) );
 
         // World
         $info .= ( ( $perms & 0x0004 ) ? 'r' : '-' );
         $info .= ( ( $perms & 0x0002 ) ? 'w' : '-' );
         $info .= ( ( $perms & 0x0001 ) ?
-            ( ( $perms & 0x0200 ) ? 't' : 'x' ) :
-            ( ( $perms & 0x0200 ) ? 'T' : '-' ) );
+                    ( ( $perms & 0x0200 ) ? 't' : 'x' ) :
+                    ( ( $perms & 0x0200 ) ? 'T' : '-' ) );
 
         return $info;
     }
@@ -1845,7 +1844,7 @@ class util
      */
     public static function array_flatten(array $array, $preserve_keys = TRUE)
     {
-        $flattened = [];
+        $flattened = array();
 
         array_walk_recursive($array, function($value, $key) use (&$flattened, $preserve_keys) {
             if ($preserve_keys && !is_int($key)) {
@@ -1874,7 +1873,7 @@ class util
      */
     public static function array_pluck( array $array, $field, $preserve_keys = TRUE, $remove_nomatches = TRUE )
     {
-        $new_list = [];
+        $new_list = array();
 
         foreach ( $array as $key => $value ) {
             if ( is_object( $value ) ) {
@@ -1967,8 +1966,8 @@ class util
     {
         foreach ( $array as $key => $value ) {
             if ( is_array( $value ) ) {
-                $args = [ $value, $callback, $on_nonscalar ];
-                $array[$key] = call_user_func_array( [ __CLASS__, __FUNCTION__ ], $args );
+                $args = array( $value, $callback, $on_nonscalar );
+                $array[$key] = call_user_func_array( array( __CLASS__, __FUNCTION__ ), $args );
             } else if ( is_scalar( $value ) || $on_nonscalar ) {
                 $array[$key] = call_user_func( $callback, $value );
             }

--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -1467,9 +1467,9 @@ class util
             $bytes = openssl_random_pseudo_bytes( $length * 2 );
             if ( $bytes === FALSE )
             {
-                throw new \RuntimeException('Unable to generate random string.');
+                throw new \LengthException( '$length is not accurate, unable to generate random string' );
             }
-            return substr( str_replace( ['/', '+', '='], '', base64_encode( $bytes )), 0, $length );
+            return substr( str_replace( array('/', '+', '='), '', base64_encode( $bytes )), 0, $length );
         }
         return static::random_string($length);
     }


### PR DESCRIPTION
Added new method `secure_random_string` that uses `openssl_random_pseudo_bytes` to generate best possible random string of given length. If `openssl_random_pseudo_bytes` not avaible then script will use default `random` generator.

Also added default length of `16` to both `random_string` and `secure_random_string`