### PR TITLE
Added more tests for seems_utf8.

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -520,6 +520,19 @@ class util
             return mb_check_encoding( $string, 'UTF-8' );
         }
 
+        // @codeCoverageIgnoreStart
+        return self::seems_utf8_worker( $string );
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * A non-Mbstring UTF-8 checker.
+     *
+     * @param $string
+     * @return bool
+     */
+    protected static function seems_utf8_worker( $string )
+    {
         $regex = '/(
 | [\xF8-\xFF] # Invalid UTF-8 Bytes
 | [\xC0-\xDF](?![\x80-\xBF]) # Invalid UTF-8 Sequence Start


### PR DESCRIPTION
* Added a fully-valid UTF-8 string test.
* Added checks to ensure the testing system's character encodings system is properly configured.
* Added a method for testing private and protected class methods (UtilTest::getMethod()).
* Added tests against the pure PHP is_utf8 code.

**NOTE:** This pull request has one failed test case in it, because the pure PHP UTF-8 detection code is bugged and returns false for a perfectly valid UTF-8 string.