### PR TITLE
Fixes for util::rmdir().

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -909,13 +909,14 @@ class util
      * @param  string $dir              The directory to be deleted recursively
      * @param  bool   $traverseSymlinks Delete contents of symlinks recursively
      * @return bool
+     * @throws \RuntimeException
      */
     public static function rmdir($dir, $traverseSymlinks = false)
     {
         if (!file_exists($dir)) {
             return true;
         } elseif (!is_dir($dir)) {
-            throw new \Exception('Given path is not a directory');
+            throw new \RuntimeException('Given path is not a directory');
         }
 
         if (!is_link($dir) || $traverseSymlinks) {
@@ -929,20 +930,29 @@ class util
                 if (is_dir($currentPath)) {
                     self::rmdir($currentPath, $traverseSymlinks);
                 } elseif (!unlink($currentPath)) {
-                    throw new \Exception('Unable to delete ' . $currentPath);
+                    // @codeCoverageIgnoreStart
+                    throw new \RuntimeException('Unable to delete ' . $currentPath);
+                    // @codeCoverageIgnoreEnd
                 }
             }
         }
 
-        if (is_link($dir)) {
+        // Windows treats removing directory symlinks identically to removing directories.
+        if (is_link($dir) && !defined('PHP_WINDOWS_VERSION_MAJOR')) {
             if (!unlink($dir)) {
-                throw new \Exception('Unable to delete ' . $dir);
+                // @codeCoverageIgnoreStart
+                throw new \RuntimeException('Unable to delete ' . $dir);
+                // @codeCoverageIgnoreEnd
             }
         } else {
             if (!rmdir($dir)) {
-                throw new \Exception('Unable to delete ' . $dir);
+                // @codeCoverageIgnoreStart
+                throw new \RuntimeException('Unable to delete ' . $dir);
+                // @codeCoverageIgnoreEnd
             }
         }
+
+        return true;
     }
 
     /**

--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -520,16 +520,33 @@ class util
             return mb_check_encoding( $string, 'UTF-8' );
         }
 
+        // @codeCoverageIgnoreStart
+        return self::seems_utf8_worker( $string );
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * A non-Mbstring UTF-8 checker.
+     *
+     * @param $string
+     * @return bool
+     */
+    protected static function seems_utf8_worker( $string )
+    {
+        // Obtained from http://stackoverflow.com/a/11709412/430062 with permission.
         $regex = '/(
-| [\xF8-\xFF] # Invalid UTF-8 Bytes
-| [\xC0-\xDF](?![\x80-\xBF]) # Invalid UTF-8 Sequence Start
-| [\xE0-\xEF](?![\x80-\xBF]{2}) # Invalid UTF-8 Sequence Start
-| [\xF0-\xF7](?![\x80-\xBF]{3}) # Invalid UTF-8 Sequence Start
-| (?<=[\x0-\x7F\xF8-\xFF])[\x80-\xBF] # Invalid UTF-8 Sequence Middle
-| (?<![\xC0-\xDF]|[\xE0-\xEF]|[\xE0-\xEF][\x80-\xBF]|[\xF0-\xF7]|[\xF0-\xF7][\x80-\xBF]|[\xF0-\xF7][\x80-\xBF]{2})[\x80-\xBF] # Overlong Sequence
-| (?<=[\xE0-\xEF])[\x80-\xBF](?![\x80-\xBF]) # Short 3 byte sequence
-| (?<=[\xF0-\xF7])[\x80-\xBF](?![\x80-\xBF]{2}) # Short 4 byte sequence
-| (?<=[\xF0-\xF7][\x80-\xBF])[\x80-\xBF](?![\x80-\xBF]) # Short 4 byte sequence (2)
+    [\xC0-\xC1] # Invalid UTF-8 Bytes
+    | [\xF5-\xFF] # Invalid UTF-8 Bytes
+    | \xE0[\x80-\x9F] # Overlong encoding of prior code point
+    | \xF0[\x80-\x8F] # Overlong encoding of prior code point
+    | [\xC2-\xDF](?![\x80-\xBF]) # Invalid UTF-8 Sequence Start
+    | [\xE0-\xEF](?![\x80-\xBF]{2}) # Invalid UTF-8 Sequence Start
+    | [\xF0-\xF4](?![\x80-\xBF]{3}) # Invalid UTF-8 Sequence Start
+    | (?<=[\x0-\x7F\xF5-\xFF])[\x80-\xBF] # Invalid UTF-8 Sequence Middle
+    | (?<![\xC2-\xDF]|[\xE0-\xEF]|[\xE0-\xEF][\x80-\xBF]|[\xF0-\xF4]|[\xF0-\xF4][\x80-\xBF]|[\xF0-\xF4][\x80-\xBF]{2})[\x80-\xBF] # Overlong Sequence
+    | (?<=[\xE0-\xEF])[\x80-\xBF](?![\x80-\xBF]) # Short 3 byte sequence
+    | (?<=[\xF0-\xF4])[\x80-\xBF](?![\x80-\xBF]{2}) # Short 4 byte sequence
+    | (?<=[\xF0-\xF4][\x80-\xBF])[\x80-\xBF](?![\x80-\xBF]) # Short 4 byte sequence (2)
 )/x';
 
         return ! preg_match( $regex, $string );

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -739,5 +739,26 @@ class UtilityPHPTest extends PHPUnit_Framework_TestCase
             $this->assertFalse(is_file($file1));
             $this->assertFalse(is_file($file2));
         }
+
+        // Test symlink traversal.
+        $dir = $dirname . '/test6';
+        $nestedDir = "$dir/nested";
+        $symlink = "$dir/nested-symlink";
+
+        mkdir($dir);
+        mkdir($nestedDir);
+
+        $symlinkStatus = symlink($nestedDir, $symlink);
+        $this->assertTrue($symlinkStatus, 'The test system does not support making symlinks.');
+
+        if (!$symlink) {
+            return;
+        }
+
+        $this->assertTrue(util::rmdir($symlink, true), 'Could not delete a symlinked directory.');
+        $this->assertFalse(file_exists($symlink), 'Could not delete a symlinked directory.');
+        util::rmdir($dir, true);
+        $this->assertFalse(is_dir($dir), 'Could not delete a directory with a symlinked directory inside of it.');
+
     }
 }


### PR DESCRIPTION
* Refactored generic \Exceptions to \RuntimeExceptions.
* Refactored to return true on success (instead of null).
* Fixed the ability to remove symlinks to directories on Windows systems.