### PR TITLE
Removed incorrect phpdoc param from older implementation

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -260,8 +260,7 @@ class util
      * concisely access an index which may or may not exist without
      * raising a warning.
      *
-     * @param  array  $var     Array to access
-     * @param  string $field   Index to access in the array
+     * @param  array  $var     Array value to access
      * @param  mixed  $default Default value to return if the key is not
      *                         present in the array
      * @return mixed


### PR DESCRIPTION
I just removed a comment that has either been left over from an old/alternative implementation for the array_get function.

I removed the comment relating to the param 'field'. It could also be worth adding a usage example  since I've noticed at least one reported(and closed) issue where a user has misunderstood usage, Thanks. 