### PR TITLE
Fix for two extraneous null bytes in var_dump().

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -455,11 +455,11 @@ class util
             foreach ($varArray as $key => $value) {
                 if (substr($key, 0, 2) == "\0*") {
                     unset($varArray[$key]);
-                    $key = 'protected:' . substr($key, 2);
+                    $key = 'protected:' . substr($key, 3);
                     $varArray[$key] = $value;
                 } elseif (substr($key, 0, 1) == "\0") {
                     unset($varArray[$key]);
-                    $key = 'private:' . substr($key, 1, strpos(substr($key, 1), "\0")) . ':' . substr($key, strpos(substr($key, 1), "\0") + 1);
+                    $key = 'private:' . substr($key, 1, strpos(substr($key, 1), "\0")) . ':' . substr($key, strpos(substr($key, 1), "\0") + 2);
                     $varArray[$key] = $value;
                 }
 


### PR DESCRIPTION
Pretty serious bug in var_dump() where it accidentally inserts null bytes in two places dealing with object printing. This breaks all sorts of C functions, like `strpos()` and the like.

This is the primary reason why I have found `var_dump()` so frickin impossible to write tests for, since PHPUnit barfs and claims the string is binary data.

See [**PHP.Net: Null bytes related issues**](http://php.net/manual/en/security.filesystem.nullbytes.php) for more information.