### PR TITLE
add_query_arg(): Properly handle valueless parameters.

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -795,15 +795,22 @@ class util
             $queryParams = $newParams;
         }
 
-        // Strip out any query params that are set to false
+        // Strip out any query params that are set to false.
+        // Properly handle valueless parameters.
         foreach ($queryParams as $param => $value) {
             if ($value === false) {
                 unset($queryParams[$param]);
+            } elseif ($value === null) {
+                $queryParams[$param] = '';
             }
         }
 
         // Re-construct the query string
         $puri['query'] = http_build_query($queryParams);
+
+        // Strip = from valueless parameters.
+        $puri['query'] = preg_replace('/=(?=&|$)/', '', $puri['query']);
+
 
         // Re-construct the entire URL
         $nuri = self::http_build_url($puri);
@@ -830,10 +837,10 @@ class util
     public static function remove_query_arg($keys, $uri = null)
     {
         if (is_array($keys)) {
-            return self::add_query_arg(array_combine($keys, array_fill(0, count($keys), null)), $uri);
+            return self::add_query_arg(array_combine($keys, array_fill(0, count($keys), false)), $uri);
         }
 
-        return self::add_query_arg(array($keys => null), $uri);
+        return self::add_query_arg(array($keys => false), $uri);
     }
 
     /**

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -231,6 +231,10 @@ class UtilityPHPTest extends PHPUnit_Framework_TestCase
         $this->assertEquals( '/app/admin/users?action=edit&tab=personal&user=5', util::add_query_arg( 'user', 5, '/app/admin/users?action=edit&tab=personal' ) );
         $this->assertEquals( '/app/admin/users?action=edit&tab=personal&user=5', util::add_query_arg( array( 'user' => 5 ), '/app/admin/users?action=edit&tab=personal' ) );
 
+        // With valueless parameters.
+        $this->assertEquals( '/index.php?debug', util::add_query_arg( 'debug', null, '/index.php' ) );
+        $this->assertEquals( '/index.php?debug#hash', util::add_query_arg( 'debug', null, '/index.php#hash' ) );
+
         // With a URL fragment
         $this->assertEquals( '/app/admin/users?user=5#test', util::add_query_arg( 'user', 5, '/app/admin/users#test' ) );
 


### PR DESCRIPTION
This properly handles the URI specification for valueless parameters.
This is functionality which is sorely missing in all internal PHP
functions, particularly http_build_query().

    echo util::add_query_arg('debug', null, '/index.php');
    // Output: /index.php?debug

Slight Backward-Compatibility break (so may have to go in 1.2.0): add_query_arg('param', null) now returns a valueless parameters (e.g., ?toggle), where before it would be completely stripped from the query string.