### PR TITLE
Updated limit_characters function phpdoc and spelling mistake

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -1842,11 +1842,12 @@ class util
 
 
     /**
-     * Truncate the string to given length of charactes.
+     * Truncate the string to given length of characters.
      *
-     * @param $string
-     * @param $limit
-     * @param string $append
+     * @param integer $string The variable to truncate
+     * @param integer $limit  The length to truncate the string to
+     * @param string  $append Text to append to the string IF it gets
+     *                        truncated, defaults to '...'
      * @return string
      */
     public static function limit_characters($string, $limit = 100, $append = '...')

--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -1844,7 +1844,7 @@ class util
     /**
      * Truncate the string to given length of characters.
      *
-     * @param integer $string The variable to truncate
+     * @param string  $string The variable to truncate
      * @param integer $limit  The length to truncate the string to
      * @param string  $append Text to append to the string IF it gets
      *                        truncated, defaults to '...'


### PR DESCRIPTION
I first updated a spelling mistake in the phpdoc description for the limit_characters function. Then also added param descriptions