### PR TITLE
Removed a superfluous 'w'

### DIFF
--- a/index.html
+++ b/index.html
@@ -597,7 +597,7 @@ util::slugify('Another String', '.');
                     <p><strong>Usage:</strong></p>
 
                     <pre>util::linkify('this string has a link to http://www.google.com');
-=&gt; Returns 'this string has a link to &lt;a href="http://wwww.google.com/"&gt;www.google.com&lt;/a&gt;'</pre>
+=&gt; Returns 'this string has a link to &lt;a href="http://www.google.com/"&gt;www.google.com&lt;/a&gt;'</pre>
                 </article>
 
                 <article id="match_string">


### PR DESCRIPTION
Fixed a (very) minor issue in the documentation entry for `util::linkify` such that the example reflects the function's actual results.