### PR TITLE
Add is_assoc_array() ad is_numeric_array()

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -323,6 +323,43 @@ class util
     }
 
     /**
+     * Returns boolean if a function is an associative array
+     *
+     * @param  array   $array        An array to test
+     *
+     * @return boolean
+     */
+    public static function is_assoc_array($array)
+    {
+        if (!is_array($array)) { return false; }
+        // $array = array() is not associative
+        if (sizeof($array) === 0) { return false; }
+
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+
+    /**
+     * Returns boolean if a function is flat/sequential numeric array
+     *
+     * @param  array   $array        An array to test
+     *
+     * @return boolean
+     */
+    public static function is_numeric_array($array)
+    {
+        if (!is_array($array)) { return false; }
+
+        $current = 0;
+        foreach (array_keys($array) as $key) {
+            if ($key !== $current) { return false; }
+
+            $current++;
+        }
+
+        return true;
+    }
+
+    /**
      * Display a variable's contents using nice HTML formatting and will
      * properly display the value of booleans as true or false
      *

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -369,6 +369,32 @@ class UtilityPHPTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('hello', 'world', 'this', 'is', 'a', 'test', 'word'), util::integerarray_remove_duplicates($array));
 	}
 	
+    public function test_is_numeric_array()
+    {
+        $this->assertTrue( util::is_numeric_array(array()) );
+        $this->assertTrue( util::is_numeric_array(array(5,6,7)) );
+        $this->assertTrue( util::is_numeric_array(array(0 => 3, 1 => 3, 2 => 3)) );
+        $this->assertTrue( util::is_numeric_array(array('foo','bar','baz')) );
+
+        $this->assertFalse( util::is_numeric_array('foo') );
+        $this->assertFalse( util::is_numeric_array(array('foo' => 'bar')) );
+        $this->assertFalse( util::is_numeric_array(1,2,3) );
+        $this->assertFalse( util::is_numeric_array(array("foo" => array('nested'=>'array'))) );
+        $this->assertFalse( util::is_numeric_array(array(0 => 3, 2 => 3, 3 => 3)) );
+    }
+
+    public function test_is_assoc_array()
+    {
+        $this->assertTrue( util::is_assoc_array(array('foo'=>'bar','color'=>'yellow')) );
+        $this->assertTrue( util::is_assoc_array(array("foo" => array('nested'=>'array'))) );
+        $this->assertTrue( util::is_assoc_array(array(1 => "baz",'two' => 'bar')) );
+
+        $this->assertFalse( util::is_assoc_array(array(1,2,3)) );
+        $this->assertFalse( util::is_assoc_array("foo") );
+        $this->assertFalse( util::is_assoc_array(array(array('nested'=>'array'))) );
+        $this->assertFalse( util::is_assoc_array(array()) );
+    }
+
     public function test_array_pluck()
     {
         $array = array(


### PR DESCRIPTION
Often I'll want to know if the data I have is an associative array (i.e. a hash), or if it's a flat numeric array (0,1,2). My use case for this is in unit testing where I want to see if a function is returning the correct data type (hash vs array). For example `array_keys()` always returns an array, while `pathinfo()` always returns a hash.

I added two functions to test for this, and their associated unit tests.

In my mind (I come from a Perl world) there are "arrays" and "hashes". I'd be open to renaming these functions to `is_hash()` and `is_array()`, but that's because that's what I'm used to in Perl. There isn't an exact mapping in PHP. Thoughts?

