### PR TITLE
Added support for proxies in is_https()

### DIFF
--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -279,7 +279,7 @@ class util
 
         self::$regex = '/[' . self::$chars . ']/u';
     }
-    
+
     /**
      * Remove the duplicates from an array.
      *
@@ -770,9 +770,15 @@ class util
      *
      * @return boolean
      */
-    public static function is_https()
+    public static function is_https($trust_proxy_headers = FALSE)
     {
-        return isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off';
+      //Check standard HTTPS header
+      if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')
+         return isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off';
+      //Check proxy headers if allowed
+      return $trust_proxy_headers && isset($_SERVER['X-FORWARDED-PROTO']) && $_SERVER['X-FORWARDED-PROTO']=='https';
+      //Default to not SSL
+      return false;
     }
 
     /**

--- a/src/utilphp/util.php
+++ b/src/utilphp/util.php
@@ -772,13 +772,13 @@ class util
      */
     public static function is_https($trust_proxy_headers = FALSE)
     {
-      //Check standard HTTPS header
-      if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')
-         return isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off';
-      //Check proxy headers if allowed
-      return $trust_proxy_headers && isset($_SERVER['X-FORWARDED-PROTO']) && $_SERVER['X-FORWARDED-PROTO']=='https';
-      //Default to not SSL
-      return false;
+        //Check standard HTTPS header
+        if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')
+            return isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off';
+        //Check proxy headers if allowed
+        return $trust_proxy_headers && isset($_SERVER['X-FORWARDED-PROTO']) && $_SERVER['X-FORWARDED-PROTO']=='https';
+        //Default to not SSL
+        return false;
     }
 
     /**


### PR DESCRIPTION
Simply adds a `$trust_proxy_headers` param defaulting to `FALSE` (similar to the `get_client_ip()` param) and checks the header `X-FORWARDED-PROTO` if `$trust_proxy_headers` is true.
Closes issue #106 