### PR TITLE
Updated "Documentation" URL to fix 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ UtilPHP is licensed under the MIT license.
 
 ## Resources
 
-* [Documentation](http://brandonwamboldt.github.com/utilphp/)
+* [Documentation](http://brandonwamboldt.github.io/utilphp/)


### PR DESCRIPTION
We should use **brandonwamboldt.github.io** instead. Because subdomains of **github.com** are **deprecated for GitHub Pages**. They are not redirecting to github.io after April 15, 2021.
Official announcement here: [https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/](https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/)